### PR TITLE
Fix wrapping kpoints at -0.5/0.5

### DIFF
--- a/easyunfold/utils.py
+++ b/easyunfold/utils.py
@@ -209,13 +209,15 @@ def wrap_kpoints(kpoints: Union[list, np.ndarray]):
     kpoints = np.array(kpoints) + 0.5
     kpoints -= np.floor(kpoints)
     kpoints -= 0.5
+    # Giving some numerical tolerance when enforcing the range [-0.5, 0.5)
+    kpoints[np.abs(kpoints - 0.5) < 1e-7] = -0.5
     return kpoints
 
 
 def find_unique(seq: np.ndarray, func=None):
     """
     Find unique slices along the first dimension of an np.array.
-    This is function is not optimised for high performance and has a O(N^2) scaling.
+    This function is not optimised for high performance and has a O(N^2) scaling.
 
     :return: A tuple of (unique, unique_idx, inv_mapping)
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,7 +77,7 @@ def test_generate_agsbte2(agsbte2_project_dir):
     assert 'Unfolding settings written to test' in output.output
 
     kpts = read_kpoints('KPOINTS_test')[0]
-    kpts_expected = 1023
+    kpts_expected = 993
     assert len(kpts) == kpts_expected
 
     # test with also specifying transformation matrix:
@@ -105,7 +105,7 @@ def test_generate_agsbte2(agsbte2_project_dir):
     assert 'Unfolding settings written to test' in output.output
 
     kpts = read_kpoints('KPOINTS_test')[0]
-    kpts_expected = 1023
+    kpts_expected = 993
     assert len(kpts) == kpts_expected
 
 


### PR DESCRIPTION
Enforce that the kpoints to be wrapped between [-0.5, 0.5), as the previous code may generate both -0.5 and 0.5 due to finite precision. This is achieved by check if the wrapped point is close to 0.5 (<1e-7). If so, it will be changed to -0.5.