### PR TITLE
Improve k point labelling when there are discontinuities in the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ If you use `easyunfold` in your work, please cite:
 We'll add papers that use `easyunfold` to this list as they come out!
 
 - K. Eggestad, B. A. D. Williamson, D. Meier and S. M. Selbach **_Mobile Intrinsic Point Defects for Conductive Neutral Domain Walls in LiNbO<sub>3</sub>_** [_ChemRxiv_](https://chemrxiv.org/engage/chemrxiv/article-details/6687aa33c9c6a5c07a59a394) 2024
+- L. Zhang et al. **_Study of native point defects in Al<sub>0.5</sub>Ga<sub>0.5</sub>N by first principles calculations_** [_Computational Materials Science_](https://doi.org/10.1016/j.commatsci.2024.113312) 2024
 - S. M. Liga & S. R. Kavanagh, A. Walsh, D. O. Scanlon and G. Konstantatos **_Mixed-Cation Vacancy-Ordered Perovskites (Cs<sub>2</sub>Ti<sub>1–x</sub>Sn<sub>x</sub>X<sub>6</sub>; X = I or Br): Low-Temperature Miscibility, Additivity, and Tunable Stability_** [_Journal of Physical Chemistry C_](https://doi.org/10.1021/acs.jpcc.3c05204) 2023
 - Y. T. Huang & S. R. Kavanagh et al. **_Strong absorption and ultrafast localisation in NaBiS<sub>2</sub> nanocrystals with slow charge-carrier recombination_** [_Nature Communications_](https://www.nature.com/articles/s41467-022-32669-3) 2022
 - A. T. J. Nicolson et al. **_Interplay of Static and Dynamic Disorder in the Mixed-Metal Chalcohalide Sn<sub>2</sub>SbS<sub>2</sub>I<sub>3</sub>_** [_Journal of the Americal Chemical Society_](https://doi.org/10.1021/jacs.2c13336) 2023

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ If you use `easyunfold` in your work, please cite:
 We'll add papers that use `easyunfold` to this list as they come out!
 
 - K. Eggestad, B. A. D. Williamson, D. Meier and S. M. Selbach **_Mobile Intrinsic Point Defects for Conductive Neutral Domain Walls in LiNbO<sub>3</sub>_** [_ChemRxiv_](https://chemrxiv.org/engage/chemrxiv/article-details/6687aa33c9c6a5c07a59a394) 2024
+- L. Zhang et al. **_Study of native point defects in Al<sub>0.5</sub>Ga<sub>0.5</sub>N by first principles calculations_** [_Computational Materials Science_](https://doi.org/10.1016/j.commatsci.2024.113312) 2024
 - S. M. Liga & S. R. Kavanagh, A. Walsh, D. O. Scanlon and G. Konstantatos **_Mixed-Cation Vacancy-Ordered Perovskites (Cs<sub>2</sub>Ti<sub>1–x</sub>Sn<sub>x</sub>X<sub>6</sub>; X = I or Br): Low-Temperature Miscibility, Additivity, and Tunable Stability_** [_Journal of Physical Chemistry C_](https://doi.org/10.1021/acs.jpcc.3c05204) 2023
 - Y. T. Huang & S. R. Kavanagh et al. **_Strong absorption and ultrafast localisation in NaBiS<sub>2</sub> nanocrystals with slow charge-carrier recombination_** [_Nature Communications_](https://www.nature.com/articles/s41467-022-32669-3) 2022
 - A. T. J. Nicolson et al. **_Interplay of Static and Dynamic Disorder in the Mixed-Metal Chalcohalide Sn<sub>2</sub>SbS<sub>2</sub>I<sub>3</sub>_** [_Journal of the Americal Chemical Society_](https://doi.org/10.1021/jacs.2c13336) 2023

--- a/easyunfold/__init__.py
+++ b/easyunfold/__init__.py
@@ -2,4 +2,4 @@
 Collection of code for band unfolding
 """
 
-__version__ = '0.3.6'
+__version__ = '0.3.7'

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -372,7 +372,7 @@ class UnfoldPlotter:
     def _add_kpoint_labels(self, ax: plt.Axes, x_is_kidx=False):
         """Add labels to the k-points for a given axes"""
         # Label the kpoints
-        labels = self.unfold.kpoint_labels
+        labels = self.unfold.get_combined_kpoint_labels()
         kdist = self.unfold.get_kpoint_distances()
 
         # Explicit label indices

--- a/easyunfold/unfold.py
+++ b/easyunfold/unfold.py
@@ -615,7 +615,7 @@ class UnfoldKSet(MSONable):
             output[key] = getattr(self, key)
         return output
 
-    def get_kpoint_distances(self):
+    def get_kpoint_distances(self, hide_discontinuities=True):
         """
         Distances between the kpoints along the path in the reciprocal space.
         This does not take account of the breaking of the path.
@@ -623,13 +623,37 @@ class UnfoldKSet(MSONable):
         The reciprocal lattice vectors includes the $2\\pi$ factor, e.g. `np.linalg.inv(L).T * 2 * np.pi`.
         :::
         """
+        # Check for
         kpts = self.kpts_pc
         pc_latt = self.pc_latt
         kpts_path = kpts @ np.linalg.inv(pc_latt).T * np.pi * 2  # Kpoint path in the reciprocal space
         dists = np.cumsum(np.linalg.norm(np.diff(kpts_path, axis=0), axis=-1))
         dists = np.append([0], dists)
 
+        if hide_discontinuities:
+            last_idx = -2
+            for idx, _ in self.kpoint_labels:
+                if idx - last_idx == 1:
+                    # This label is directly adjacent to the previous one - this is a discontinuity
+                    shift = dists[idx] - dists[idx - 1]
+                    # Shift the distances beyond
+                    dists[idx:] -= shift
+                last_idx = idx
+
         return dists
+
+    def get_combined_kpoint_labels(self):
+        """Get kpoints label with discontinuities combined into a single label"""
+        last_entry = [-2, None]
+        comnbined_labels = []
+        for idx, name in self.kpoint_labels:
+            if idx - last_entry[0] == 1:
+                comnbined_labels.append([last_entry[0], last_entry[1] + '|' + name])
+            else:
+                comnbined_labels.append([idx, name])
+            last_entry = [idx, name]
+
+        return comnbined_labels
 
 
 def LorentzSmearing(x, x0, sigma=0.02):

--- a/easyunfold/unfold.py
+++ b/easyunfold/unfold.py
@@ -615,10 +615,13 @@ class UnfoldKSet(MSONable):
             output[key] = getattr(self, key)
         return output
 
-    def get_kpoint_distances(self, hide_discontinuities=True):
+    def get_kpoint_distances(self, hide_discontinuities: bool = True):
         """
         Distances between the kpoints along the path in the reciprocal space.
         This does not take account of the breaking of the path.
+
+        :param hide_discontinuities: Whether to hide the discontinuities in the kpoint path.
+
         :::{note}
         The reciprocal lattice vectors includes the $2\\pi$ factor, e.g. `np.linalg.inv(L).T * 2 * np.pi`.
         :::


### PR DESCRIPTION
Combine the labels of points when there is a discontinuity. Such points are labelled by the `A|B` sytax. 

Example: 

![figure](https://github.com/user-attachments/assets/eae950bf-a54e-4b79-97e9-ca47a6091fbf)

This fixes issue #49 where the flat bands are caused using the apparent distance between two k-point where the path was discontinuous.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated version to 0.3.7, indicating minor improvements and bug fixes.
	- Introduced a new parameter in the k-point distance calculations to control the visibility of discontinuities.
	- Added a new method for generating combined k-point labels, enhancing k-point representation.
  
- **Bug Fixes**
	- Improved robustness in retrieving k-point labels.

- **Documentation**
	- Added citation for L. Zhang et al.'s study to the README and documentation, enhancing user resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->