### PR TITLE
Update band interpolation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |
@@ -47,11 +47,11 @@ jobs:
       run: |
         pytest tests/
     - name: Run coverage from coverage-python by running pytest yet again
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version == '3.10' }}
       run: pytest --cov-report=xml --cov-append --cov=easyunfold
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version == '3.9' }}
-      uses: codecov/codecov-action@v3
+      if: ${{ matrix.python-version == '3.10' }}
+      uses: codecov/codecov-action@v5
       with:
         name: easyunfold
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -64,11 +64,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Build
         run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -422,4 +422,5 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/docs/examples/example_si222.md
+++ b/docs/examples/example_si222.md
@@ -171,7 +171,7 @@ output:
 :alt: Spectral function
 :width: 400px
 
-Spectral function of the unfolded bands with out additional kpoints due to reduced symmetry.
+Spectral function of the unfolded bands without additional kpoints due to reduced symmetry.
 ```
 
 Comparing this plot with the one above, we see that we get spurious band breaking (e.g. along $\Gamma - L$)

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -234,7 +234,7 @@ class UnfoldPlotter:
             axes = [ax] if not isinstance(ax, list) else ax
             fig = axes[0].figure
 
-        # Shift the kdist so the pcolormesh draw the pixel centred on the original point
+        # Shift the kdist so the plot draws the pixel centred on the original point
         X, Y = np.meshgrid(kdist, engs - eref)
 
         # Calculate the min and max values within the field of view, scaled by the factor
@@ -250,7 +250,14 @@ class UnfoldPlotter:
             if contour_plot:
                 ax_.contourf(X, Y, sf[ispin], cmap=cmap, vmax=vmax, vmin=vmin, alpha=alpha)
             else:
-                ax_.pcolormesh(X, Y, sf[ispin], cmap=cmap, shading='auto', vmax=vmax, vmin=vmin, alpha=alpha)
+                ax_.imshow(sf[ispin],
+                           cmap=cmap,
+                           aspect='auto',
+                           extent=(X.min(), X.max(), Y.min(), Y.max()),
+                           vmin=vmin,
+                           vmax=vmax,
+                           alpha=alpha,
+                           origin='lower')
 
             ax_.set_xlim(xmin, xmax)
             ax_.set_ylim(*ylim)

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -246,18 +246,12 @@ class UnfoldPlotter:
             vmax = (vmax - vmin) * (vscale /
                                     intensity) + vmin  # vscale and intensity have the equal opposite effect on the colour intensity
 
+        plot_kwargs = {'cmap': cmap, 'vmax': vmax, 'vmin': vmin, 'alpha': alpha}
         for ispin, ax_ in zip(range(nspin), axes):
             if contour_plot:
-                ax_.contourf(X, Y, sf[ispin], cmap=cmap, vmax=vmax, vmin=vmin, alpha=alpha)
-            else:
-                ax_.imshow(sf[ispin],
-                           cmap=cmap,
-                           aspect='auto',
-                           extent=(X.min(), X.max(), Y.min(), Y.max()),
-                           vmin=vmin,
-                           vmax=vmax,
-                           alpha=alpha,
-                           origin='lower')
+                ax_.contourf(X, Y, sf[ispin], **plot_kwargs)
+            else:  # TODO: comment
+                ax_.pcolormesh(X, Y, sf[ispin], shading='gouraud', **plot_kwargs)
 
             ax_.set_xlim(xmin, xmax)
             ax_.set_ylim(*ylim)

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -818,6 +818,8 @@ class UnfoldPlotter:
         ax.plot(x, y, 'x-', label='Energy ')
         ax.plot(x, y1, label='fitted')
         ax.legend()
+
+        fig = ax.figure
         if save:
             fig.savefig(save, dpi=dpi)
         return fig

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -41,13 +41,13 @@ class UnfoldPlotter:
         self.unfold = unfold
 
     @staticmethod
-    def plot_dos(ax, dos_plotter, dos_label, dos_options, ylim, eref, atoms=None, colours=None, orbitals_subplots=None):
+    def plot_dos(ax, dos_plotter, ylim, eref, dos_label=None, dos_options=None, atoms=None, colours=None, orbitals_subplots=None):
         """
         Prepare and plot the density of states.
         """
         from pymatgen.electronic_structure.core import Spin
 
-        if not dos_options:
+        if dos_options is None:
             dos_options = {}
 
         from sumo.plotting import sumo_base_style, sumo_bs_style
@@ -250,7 +250,7 @@ class UnfoldPlotter:
         for ispin, ax_ in zip(range(nspin), axes):
             if contour_plot:
                 ax_.contourf(X, Y, sf[ispin], **plot_kwargs)
-            else:  # TODO: comment
+            else:  # note that pcolormesh is used over imshow to allow non-uniform k-point meshes
                 ax_.pcolormesh(X, Y, sf[ispin], shading='gouraud', **plot_kwargs)
 
             ax_.set_xlim(xmin, xmax)
@@ -264,7 +264,7 @@ class UnfoldPlotter:
 
         if dos_plotter:
             ax = fig.axes[1]
-            ax = self.plot_dos(ax, dos_plotter, dos_label, dos_options, ylim, eref)
+            ax = self.plot_dos(ax, dos_plotter, ylim, eref, dos_label=dos_label, dos_options=dos_options)
 
         if zero_line:
             try:
@@ -754,7 +754,15 @@ class UnfoldPlotter:
 
             if dos_plotter:
                 ax = fig.axes[1]
-                ax = self.plot_dos(ax, dos_plotter, dos_label, dos_options, ylim, eref, atoms, colours, orbitals_subplots)
+                ax = self.plot_dos(ax,
+                                   dos_plotter,
+                                   ylim,
+                                   eref,
+                                   dos_label=dos_label,
+                                   dos_options=dos_options,
+                                   atoms=atoms,
+                                   colours=colours,
+                                   orbitals_subplots=orbitals_subplots)
 
             if zero_line:
                 try:


### PR DESCRIPTION
Just a small PR which switches from using `pcolormesh` to `imshow` in plotting, which then makes use of built-in interpolation and reduces some of the graininess of plotted grids mentioned in https://github.com/SMTG-Bham/easyunfold/issues/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Fixed a minor grammatical error in documentation for crystalline silicon unfolding process
  - Updated comment clarity in spectral function plotting method

- **Improvements**
  - Modified spectral function visualization technique using `imshow` for better rendering
  - Enhanced parameter handling in plotting methods for clarity and consistency
  - Updated exception handling configuration for stricter checks on caught exceptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->