### PR TITLE
Fix eff mass plotting w custom inputs

### DIFF
--- a/docs/examples/example_mgo.md
+++ b/docs/examples/example_mgo.md
@@ -148,14 +148,12 @@ to the VBM or CBM to assign extrema points.
 One can also inspect if the detected bands makes sense by using the `--plot` option.
 A Jupyter Notebook example can be found [here](../../examples/MgO/effective-mass.ipynb).
 
-
 ```{figure} ../../examples/MgO/unfold-effective-mass.png
 :width: 800 px
 :alt: Effective bands extracted  
 
 Extracted bands at CBM and VBM for an unfolded MgO band structure.
 ```
-
 
 :::{warning}
 Make sure the band extrema data tabulated is correct and consistent before using any of the reported values.
@@ -164,7 +162,7 @@ The results can unreliable for systems with little or no band gaps and those wit
 
 
 :::{tip}
-For complex systems where the detection is difficult, one can manually pass the kpoint and the band indices using the `--manual-extrema` option.
+For complex systems where the detection is difficult, one can manually pass the kpoint and the band indices using the `--manual-extrema` option, or can pass the eigenvalue of the band edge of interest using the `--extremum-eigenvalue` option. See `easyunfold unfold effective-mass -h` for more details.
 :::
 
 ## Defects

--- a/docs/examples/example_mgo.md
+++ b/docs/examples/example_mgo.md
@@ -111,6 +111,10 @@ There are _many_ customisation options available for the plotting functions in `
 `easyunfold unfold plot-projections -h` for more details!
 :::
 
+:::{warning}
+If your `PROCAR(.gz)` file(s) are corrupted or incomplete, the `plot-projections` command will fail with an error message like `ValueError: cannot reshape array of size 73542192 into shape (2,74,348,90,16)`. In cases where the start/end of the `PROCAR` file looks fine, this can sometimes be checked with `grep -E '[^[:print:]]' --color=never PROCAR` which will only show an output if some lines in the file are corrupted. Typically this requires re-running the VASP calculation to give an uncorrupted file. 
+:::
+
 ### Carrier Effective Masses
 
 The command `easyunfold unfold effective-mass` can be used to find the effective masses of the unfolded band structure.

--- a/docs/examples/example_mgo.md
+++ b/docs/examples/example_mgo.md
@@ -145,7 +145,7 @@ If detected band extrema are not consistent with the band structure, one should 
 Increasing the value of `--intensity-tol` will filter away bands with very small spectral weights.
 On the other hand, increasing `--extrema-detect-tol` will increase the energy window with respect 
 to the VBM or CBM to assign extrema points. 
-One can also inspect if the detected bands makes sense by using the `--plot` option.
+One can also inspect if the detected bands makes sense by using the `--plot` or `--plot-fit` options, in which case it can be useful to increase `--npoints` to extend the plotted range.
 A Jupyter Notebook example can be found [here](../../examples/MgO/effective-mass.ipynb).
 
 ```{figure} ../../examples/MgO/unfold-effective-mass.png

--- a/docs/examples/example_mgo.md
+++ b/docs/examples/example_mgo.md
@@ -141,8 +141,8 @@ Hole effective masses:
 Unfolded band structure can be ambiguous, please cross-check with the spectral function plot.
 ```
 
-If detected band extrema are not consistent with the band structure, one should adjust the `--intensity-tol` and `--extrema-detect-tol`.
-Increasing the value of `--intensity-tol` will filter away bands with very small spectral weights.
+If detected band extrema are not consistent with the band structure, or some band edges are not detected, one should adjust the `--intensity-threshold` and `--extrema-detect-tol`.
+Increasing the value of `--intensity-threshold` will filter away bands with very small spectral weights.
 On the other hand, increasing `--extrema-detect-tol` will increase the energy window with respect 
 to the VBM or CBM to assign extrema points. 
 One can also inspect if the detected bands makes sense by using the `--plot` or `--plot-fit` options, in which case it can be useful to increase `--npoints` to extend the plotted range.

--- a/docs/examples/example_mgo.md
+++ b/docs/examples/example_mgo.md
@@ -43,7 +43,7 @@ Note that the path of the `PROCAR(.gz)` is passed along with the desired atom pr
 :::{tip}
 If the _k_-points have been split into multiple calculations (e.g. hybrid DFT band structures), the `--procar` option 
 should be passed multiple times to specify the path to each split `PROCAR(.gz)` file (i.e. 
-`--procar calc1/PROCAR --procar cal2/PROCAR ...`).
+`--procar calc1/PROCAR --procar calc2/PROCAR ...`).
 :::
 
 :::{note}

--- a/docs/examples/example_nabis2.md
+++ b/docs/examples/example_nabis2.md
@@ -99,7 +99,7 @@ Unfolded band structure of NaBiS<sub>2</sub> with atomic contributions.
 :::{tip}
 If the _k_-points have been split into multiple calculations (e.g. hybrid DFT band structures), the `--procar` option 
 should be passed multiple times to specify the path to each split `PROCAR(.gz)` file (i.e. 
-`--procar calc1/PROCAR --procar cal2/PROCAR ...`).
+`--procar calc1/PROCAR --procar calc2/PROCAR ...`).
 :::
 
 From this plot, we can see that sulfur anions dominate the valence band, while bismuth cations dominate the conduction 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -201,7 +201,7 @@ BuPu `cmap`        |                     viridis `cmap`                      |  
 ![](../examples/NaBiS2/NaBiS2_unfold-plot_BuPu.png)  | ![](../examples/NaBiS2/NaBiS2_unfold-plot_viridis.png)  |  <img src="../examples/NaBiS2/NaBiS2_unfold-plot_proj.png" alt="atom-projected NaBiS2 band structure" width="1200"/>
 
 :::{tip}
-Figure can be further customised by passing a path to a matplotlib style sheet file, for example:
+The output figure can be further customised by passing a path to a matplotlib style sheet file, for example:
 
 ```
 easyunfold unfold --mpl-style-file <path-to-mpl-style-sheet> plot
@@ -209,6 +209,10 @@ easyunfold unfold --mpl-style-file <path-to-mpl-style-sheet> plot
 
 which can be used to change the font, font sizes, ticks styles etc.
 Read more on [the matplotlib tutorial page](https://matplotlib.org/stable/tutorials/introductory/customizing.html#using-style-sheets).
+:::
+
+:::{tip}
+There are a number of further plot customisation and analysis tools, such as atomic/site/orbital projections, combined plots with electronic density of states (DOS), effective mass fitting & plotting, and more. These are demonstrated in the [examples](https://smtg-bham.github.io/easyunfold/examples.html).
 :::
 
 [^vasp]: https://www.vasp.at

--- a/easyunfold/cli.py
+++ b/easyunfold/cli.py
@@ -382,7 +382,8 @@ def unfold_effective_mass(ctx, intensity_threshold, spin, band_filter, npoints, 
         plotter = UnfoldPlotter(unfoldset)
         click.echo('Generating spectral function plot for visualising detected band branches...')
         engs, sf = unfoldset.get_spectral_function()
-        plotter.plot_effective_mass(efm, engs, sf, effective_mass_data=output, save=out_file, ylim=(emin, emax))
+        plotter.plot_effective_mass(efm, engs, sf, effective_mass_data=output, save=out_file, ylim=(emin, emax),
+                                    eref=extremum_eigenvalue)  # set eref to extremum_eigenvalue if not None
 
     elif plot_fit:
         from easyunfold.plotting import UnfoldPlotter

--- a/easyunfold/cli.py
+++ b/easyunfold/cli.py
@@ -455,8 +455,9 @@ def add_plot_options(func):
     click.option('--procar',
                  multiple=True,
                  default=['PROCAR'],
-                 help=('PROCAR file(s) for atomic weighting, can be passed multiple times if more than one PROCAR '
-                       'should be used. Default is to read PROCAR(.gz) in current directory'))(func)
+                 help=('PROCAR file(s) for atomic weighting. Default is to read PROCAR(.gz) in current '
+                       'directory. If working with split k-point directories, the should be passed '
+                       'multiple times as `--procar calc1/PROCAR --procar calc2/PROCAR... `'))(func)
     click.option('--atoms',
                  help='Atoms to be used for weighting, as a comma-separated list (e.g. "Na,Bi,S"). '
                  'The POSCAR or CONTCAR file (matching `--poscar`) must be present, otherwise use `--atoms-idx`.')(func)

--- a/easyunfold/cli.py
+++ b/easyunfold/cli.py
@@ -393,7 +393,7 @@ def unfold_effective_mass(ctx, intensity_threshold, spin, band_filter, npoints, 
         for carrier in ['electrons', 'holes']:
             for idx, _ in enumerate(output[carrier]):
                 plotter.plot_effective_mass_fit(
-                    efm=efm,
+                    efm=output,
                     npoints=npoints,
                     carrier=carrier,
                     idx=int(idx),

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -427,27 +427,17 @@ class UnfoldPlotter:
         xwidth = 2 * mean_n_points * abs(kdist[1] - kdist[0])
         for (ik, ax) in zip(all_k, axes[0]):
             self.plot_spectral_function(engs, sf, ax=ax, eref=eref, **kwargs)
-            xk = kdist[ik]
-            xlim = (xk - xwidth / 2, xk + xwidth / 2)
-            ax.set_xlim(xlim)
             ax.set_title(f'Kpoint: {ik}')
 
         # Plot the detected effective mass fitting data on top
-        for entry in elec:
-            ik = entry['kpoint_index']
-            iax = all_k.index(ik)
-            x = entry['raw_data']['raw_fit_values'][0]
-            y = entry['raw_data']['raw_fit_values'][1]
-            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C1', label='m_e')
-            axes[0, iax].set_xlim(min(x) - xwidth / 2, max(x) + xwidth / 2)
-
-        for entry in hole:
-            ik = entry['kpoint_index']
-            iax = all_k.index(ik)
-            x = entry['raw_data']['raw_fit_values'][0]
-            y = entry['raw_data']['raw_fit_values'][1]
-            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C2', label='m_h')
-            axes[0, iax].set_xlim(min(x) - xwidth / 2, max(x) + xwidth / 2)
+        for carrier_type, entry_list in zip(['m_e', 'm_h'], [elec, hole]):
+            for entry in entry_list:
+                ik = entry['kpoint_index']
+                iax = all_k.index(ik)
+                x = entry['raw_data']['raw_fit_values'][0]
+                y = entry['raw_data']['raw_fit_values'][1]
+                axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C1' if carrier_type == 'm_e' else 'C2', label=carrier_type)
+                axes[0, iax].set_xlim(max(min(x) - xwidth / 2, axes[0, iax].get_xlim()[0]), max(x) + xwidth / 2)
 
         for ax in axes[0]:
             ax.legend()

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -399,26 +399,26 @@ class UnfoldPlotter:
         """
         Plot the effective masses on top of the spectral function.
 
-        :param efm: ``EffectiveMass`` object for plotting, or pre-calculated
-                    ``EffectiveMass.get_effective_masses()`` data dict.
+        :param efm: ``EffectiveMass`` object for plotting.
         :param engs: The energies of the spectral functions.
         :param sf: An array of the spectral function.
         :param eref: Reference energy to be used - this energy will be set as zero.
-        :param effective_mass_data: Calculated data of the effective masses.
+        :param effective_mass_data: Calculated data of the effective masses (i.e.
+                                    ``EffectiveMass.get_effective_masses()``).
 
         :returns: A figure with the data used for fitting effective mass plotted on top of the spectral function.
         """
+        if effective_mass_data is None:
+            effective_mass_data = efm.get_effective_masses()
+        elec = effective_mass_data.get('electrons', [])
+        hole = effective_mass_data.get('holes', [])
+        all_k = sorted({entry['kpoint_index'] for entry in elec + hole})
 
-        kcbm = efm.get_band_extrema(mode='cbm')[0]
-        kvbm = efm.get_band_extrema(mode='vbm')[0]
-        all_k = sorted(list(set(list(kcbm) + list(kvbm))))
         kdist = self.unfold.get_kpoint_distances()
         if eref is None:
             eref = self.unfold.calculated_quantities['vbm']
 
-        fig, axes = plt.subplots(1, len(all_k), figsize=(4 * len(all_k), 3), dpi=300, squeeze=False)
-        if effective_mass_data is None:
-            effective_mass_data = efm.get_effective_masses()
+        fig, axes = plt.subplots(1, len(all_k), figsize=(4 * len(all_k), 3), dpi=50, squeeze=False)
 
         # Plot the spectral function
         xwidth = abs(kdist[1] - kdist[0])
@@ -429,7 +429,6 @@ class UnfoldPlotter:
             ax.set_xlim(xlim)
             ax.set_title(f'Kpoint: {ik}')
 
-        elec = effective_mass_data.get('electrons', [])
         # Plot the detected effective mass fitting data on top
         for entry in elec:
             ik = entry['kpoint_index']
@@ -439,7 +438,6 @@ class UnfoldPlotter:
             axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C1')
             axes[0, iax].set_xlim(min(x) - xwidth / 2, max(x) + xwidth / 2)
 
-        hole = effective_mass_data.get('holes', [])
         for entry in hole:
             ik = entry['kpoint_index']
             iax = all_k.index(ik)

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -435,7 +435,7 @@ class UnfoldPlotter:
             iax = all_k.index(ik)
             x = entry['raw_data']['raw_fit_values'][0]
             y = entry['raw_data']['raw_fit_values'][1]
-            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C1')
+            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C1', label='m_e')
             axes[0, iax].set_xlim(min(x) - xwidth / 2, max(x) + xwidth / 2)
 
         for entry in hole:
@@ -443,8 +443,12 @@ class UnfoldPlotter:
             iax = all_k.index(ik)
             x = entry['raw_data']['raw_fit_values'][0]
             y = entry['raw_data']['raw_fit_values'][1]
-            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C2')
+            axes[0, iax].plot(x, np.asarray(y) - eref, '-o', color='C2', label='m_h')
             axes[0, iax].set_xlim(min(x) - xwidth / 2, max(x) + xwidth / 2)
+
+        for ax in axes[0]:
+            ax.legend()
+
         if save:
             fig.savefig(save)
 

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -418,10 +418,13 @@ class UnfoldPlotter:
         if eref is None:
             eref = self.unfold.calculated_quantities['vbm']
 
-        fig, axes = plt.subplots(1, len(all_k), figsize=(4 * len(all_k), 3), dpi=50, squeeze=False)
+        fig, axes = plt.subplots(1, len(all_k), figsize=(4 * len(all_k), 3), squeeze=False)
 
         # Plot the spectral function
-        xwidth = abs(kdist[1] - kdist[0])
+        # set xwidth to 2 * npoints * kdist-diff, so that final plot should have ~1/3 of plot having
+        # fitted data points:
+        mean_n_points = round(np.mean([len(entry['raw_data']['raw_fit_values'][0]) for entry in elec + hole]))
+        xwidth = 2 * mean_n_points * abs(kdist[1] - kdist[0])
         for (ik, ax) in zip(all_k, axes[0]):
             self.plot_spectral_function(engs, sf, ax=ax, eref=eref, **kwargs)
             xk = kdist[ik]

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -787,7 +787,7 @@ class UnfoldPlotter:
         return fig
 
     @staticmethod
-    def plot_effective_mass_fit(efm: EffectiveMass,
+    def plot_effective_mass_fit(efm: Union[EffectiveMass, dict],
                                 npoints: int = 3,
                                 carrier: str = 'electrons',
                                 idx: int = 0,
@@ -797,7 +797,8 @@ class UnfoldPlotter:
         """
         Plot detected band edges and the fitted effective masses.
 
-        :param efm: `EffectiveMass` object for plotting.
+        :param efm: `EffectiveMass` object for plotting, or pre-calculated
+                    ``EffectiveMass.get_effective_masses()`` data dict.
         :param npoints: The number of points to be used for fitting.
         :param carrier: Type of the charge carrier, e.g. `electrons` or `holes`.
         :param idx: Index for the detected effective mass of the same kind.
@@ -807,7 +808,8 @@ class UnfoldPlotter:
 
         :returns: A figure with plotted data.
         """
-        data = efm.get_effective_masses(npoints=npoints)[carrier][idx]
+        efm_output_data = efm if isinstance(efm, dict) else efm.get_effective_masses(npoints=npoints)
+        data = efm_output_data[carrier][idx]
 
         x = data['raw_data']['kpoint_distances']
         y = data['raw_data']['effective_energies']

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -388,7 +388,7 @@ class UnfoldPlotter:
         ax.set_xticklabels(tick_labels)
 
     def plot_effective_mass(self,
-                            eff: EffectiveMass,
+                            efm: EffectiveMass,
                             engs: np.ndarray,
                             sf: np.ndarray,
                             eref: Union[None, float] = None,
@@ -399,7 +399,8 @@ class UnfoldPlotter:
         """
         Plot the effective masses on top of the spectral function.
 
-        :param eff: An `EffectiveMass` object used for plotting.
+        :param efm: ``EffectiveMass`` object for plotting, or pre-calculated
+                    ``EffectiveMass.get_effective_masses()`` data dict.
         :param engs: The energies of the spectral functions.
         :param sf: An array of the spectral function.
         :param eref: Reference energy to be used - this energy will be set as zero.
@@ -408,8 +409,8 @@ class UnfoldPlotter:
         :returns: A figure with the data used for fitting effective mass plotted on top of the spectral function.
         """
 
-        kcbm = eff.get_band_extrema(mode='cbm')[0]
-        kvbm = eff.get_band_extrema(mode='vbm')[0]
+        kcbm = efm.get_band_extrema(mode='cbm')[0]
+        kvbm = efm.get_band_extrema(mode='vbm')[0]
         all_k = sorted(list(set(list(kcbm) + list(kvbm))))
         kdist = self.unfold.get_kpoint_distances()
         if eref is None:
@@ -417,7 +418,7 @@ class UnfoldPlotter:
 
         fig, axes = plt.subplots(1, len(all_k), figsize=(4 * len(all_k), 3), dpi=300, squeeze=False)
         if effective_mass_data is None:
-            effective_mass_data = eff.get_effective_masses()
+            effective_mass_data = efm.get_effective_masses()
 
         # Plot the spectral function
         xwidth = abs(kdist[1] - kdist[0])
@@ -797,7 +798,7 @@ class UnfoldPlotter:
         """
         Plot detected band edges and the fitted effective masses.
 
-        :param efm: `EffectiveMass` object for plotting, or pre-calculated
+        :param efm: ``EffectiveMass`` object for plotting, or pre-calculated
                     ``EffectiveMass.get_effective_masses()`` data dict.
         :param npoints: The number of points to be used for fitting.
         :param carrier: Type of the charge carrier, e.g. `electrons` or `holes`.

--- a/easyunfold/procar.py
+++ b/easyunfold/procar.py
@@ -102,7 +102,14 @@ class Procar(MSONable):
 
             elif line.startswith('band'):
                 tokens = line.strip().split()
-                energies.append(float(tokens[4]))
+                try:
+                    energies.append(float(tokens[4]))
+                except ValueError:
+                    # this can happen for cases where energy in PROCAR is "*****...", where the energy
+                    # is either very negative or very positive (likely outside plotting range anyway), so
+                    # set to +/-np.inf
+                    energies.append(np.sign(energies[-1] if energies else -1))
+
                 occs.append(float(tokens[-1]))
 
             elif line.startswith('tot'):

--- a/easyunfold/procar.py
+++ b/easyunfold/procar.py
@@ -69,6 +69,7 @@ class Procar(MSONable):
         # Counter for the number of sections in the PROCAR
         section_counter = 1
         _last_kid = 0
+        # _last_ion = nion  # track ion numbers to ensure all ions being parsed
         this_procar_parsed_kpoints = set()  # set with tuples of parsed (kvec tuple, section_counter) for this PROCAR
         while line:
             if line.startswith(' k-point'):
@@ -95,9 +96,14 @@ class Procar(MSONable):
                             break
                     continue  # go back to start of outer while loop, to parse this k-point
 
-            elif (not re.search(r'[a-zA-Z]', line) and line.strip() and len(line.strip().split()) - 2 == len(self.proj_names)):
+            elif not re.search(r'[a-zA-Z]', line) and line.strip() and len(line.strip().split()) - 2 == len(self.proj_names):
                 # data line, as there is only numerical values, not empty line, and expected number of
                 # columns (in case of LORBIT >= 12)
+                # DEBUGGING for corrupted PROCARs: (Uncomment these lines and _last_ion definition above)
+                # ion_no = int(line.strip().split()[0])
+                # if ion_no not in [_last_ion+1, 1]:
+                #     print(ion_no, _last_ion, line)
+                # _last_ion = ion_no
                 proj_data.append([float(token) for token in line.strip().split()[1:-1]])
 
             elif line.startswith('band'):


### PR DESCRIPTION
This PR contains a number of fixes and improvements:
- Fixes `plot_effective_mass_fit` (i.e. `easyunfold unfold effective-mass --plot-fit`) when custom effective mass fitting options (such as `manual-extrema` or `extremum-eigenvalue`) are used
- Fixes `plot_effective_mass` (i.e. `easyunfold unfold effective-mass --plot`) when custom effective mass fitting options (such as `manual-extrema` or `extremum-eigenvalue`) are used.
- Improved default choice of `xwidth` in `plot_effective_mass`
- Some docs updates to mention the effective mass plotting capabilities, with some tips
- Miscellaneous fixes and code streamlining

Tested using @Iamkeli's data. E.g. in a case where the CBM is filled (to the point where the bands appear a bit discontinuous around 1.5 eV above the CBM), the auto-band-edge detection doesn't work. But using the `extremum-eigenvalue` option allows the fitting to be performed as desired:
```
> easyunfold unfold effective-mass --plot --extremum-eigenvalue 5.41 --npoints 10

Loaded data from easyunfold.json
Band extrema data:
  Kpoint index  Kind      Sub-kpoint index    Band indices
--------------  ------  ------------------  --------------
             0  CBM                      0             289
           162  CBM                      0             289
             0  VBM                      0             289
           162  VBM                      0             289

Electron effective masses:
  index  Kind      Effective mass    Band index  from                      to
-------  ------  ----------------  ------------  ------------------------  ------------------------
      0  m_e                0.303           289  [0.0, 0.0, 0.0] (\Gamma)  [0.0, 0.0, 0.5] (A)
      1  m_e                0.214           289  [0.0, 0.0, 0.0] (\Gamma)  [0.0, 0.5, 0.0] (M)
      2  m_e                0.217           289  [0.0, 0.0, 0.0] (\Gamma)  [-0.333, 0.667, 0.0] (K)

Hole effective masses:
  index  Kind      Effective mass    Band index  from                      to
-------  ------  ----------------  ------------  ------------------------  ------------------------
      0  m_h                0.303           289  [0.0, 0.0, 0.0] (\Gamma)  [0.0, 0.0, 0.5] (A)
      1  m_h                0.214           289  [0.0, 0.0, 0.0] (\Gamma)  [0.0, 0.5, 0.0] (M)
      2  m_h                0.217           289  [0.0, 0.0, 0.0] (\Gamma)  [-0.333, 0.667, 0.0] (K)
Generating spectral function plot for visualising detected band branches...
```
(In this case the "hole effective masses" are irrelevant as we have specified the CBM eigenvalue)

<img width="800" alt="image" src="https://github.com/user-attachments/assets/1adba26d-72e3-4f70-9197-43346fcf733f" />

For reference; `easyunfold unfold plot --emax 6 --dos vasprun.xml.gz --eref 5.45`:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ba26ee94-d0a6-467c-ac51-b772e488cb5c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated guides and tutorials with clearer instructions for inspecting detected bands and output figure customization, including additional tips for extended plot customization.
	- Improved clarity in the `example_mgo.md` documentation regarding band structure analysis and command usage, including a new warning section for corrupted files.
	- Corrected formatting in the `example_nabis2.md` documentation for consistent command-line instruction presentation.
- **New Features**
	- Added a new tip section in the tutorial for various plot customization and analysis tools.
	- Introduced a reference energy option for effective mass plots, improving data visualization and fitting for both electron and hole analyses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->