### PR TITLE
Plotting updates

### DIFF
--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -778,10 +778,11 @@ class UnfoldPlotter:
                 except ImportError:
                     warnings.warn('zero_line option requires sumo to be installed!')
 
-            if atoms is not None:  # add figure legend with atoms and colors
+            if atoms is not None and dos_plotter is None:  # add figure legend with atoms and colors
                 legend_elements = [Patch(facecolor=colours[i], label=atom, alpha=0.7) for i, atom in enumerate(atoms)]
                 fig.axes[nspin - 1].legend(handles=legend_elements, bbox_to_anchor=(1.025, 1), fontsize=9)
-                fig.subplots_adjust(right=0.78)  # ensure legend is not cut off
+            if atoms is not None or dos_plotter is not None:
+                fig.subplots_adjust(right=0.78)  # compensate for the legend
 
         return fig
 

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -780,7 +780,7 @@ class UnfoldPlotter:
 
             if atoms is not None:  # add figure legend with atoms and colors
                 legend_elements = [Patch(facecolor=colours[i], label=atom, alpha=0.7) for i, atom in enumerate(atoms)]
-                fig.axes[0].legend(handles=legend_elements, bbox_to_anchor=(1.025, 1), fontsize=9)
+                fig.axes[nspin - 1].legend(handles=legend_elements, bbox_to_anchor=(1.025, 1), fontsize=9)
                 fig.subplots_adjust(right=0.78)  # ensure legend is not cut off
 
         return fig

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -359,8 +359,7 @@ class UnfoldPlotter:
             extent[2:] -= ebin * 0.5
             ax_.imshow(sf[ispin], extent=extent, aspect='auto', origin='upper')
             ax_.set_ylim(ylim)
-            ax_.set_xlim(0, sf.shape[2])
-            ax_.set_ylabel('Energy (eV)', labelpad=5)
+            ax_.set_xlim(0, sf.shape[2] - 1)
             ax_.set_title(title)
             self._add_kpoint_labels(ax_, x_is_kidx=True)
 
@@ -538,7 +537,7 @@ class UnfoldPlotter:
                 alpha=alpha,
                 lw=0.0,
             )
-            ax_.set_xlim(0, kdist.max())
+            ax_.set_xlim(0, kdist.max() - 1)
             ax_.set_ylim(ylim)
             if title:
                 ax_.set_title(title)

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -255,12 +255,13 @@ class UnfoldPlotter:
 
             ax_.set_xlim(xmin, xmax)
             ax_.set_ylim(*ylim)
-            ax_.set_ylabel('Energy (eV)', labelpad=5)
             if title:
                 ax_.set_title(title)
 
             # Label the kpoints
             self._add_kpoint_labels(ax_)
+
+        axes[0].set_ylabel('Energy (eV)', labelpad=5)
 
         if dos_plotter:
             ax = fig.axes[1]
@@ -362,6 +363,8 @@ class UnfoldPlotter:
             ax_.set_ylabel('Energy (eV)', labelpad=5)
             ax_.set_title(title)
             self._add_kpoint_labels(ax_, x_is_kidx=True)
+
+        axes[0].set_ylabel('Energy (eV)', labelpad=5)
 
         fig.tight_layout(pad=0.2)
         if save:
@@ -537,10 +540,11 @@ class UnfoldPlotter:
             )
             ax_.set_xlim(0, kdist.max())
             ax_.set_ylim(ylim)
-            ax_.set_ylabel('Energy [eV]', labelpad=5)
             if title:
                 ax_.set_title(title)
             self._add_kpoint_labels(ax_)
+
+        axes[0].set_ylabel('Energy [eV]', labelpad=5)
 
         fig.tight_layout(pad=0.2)
 

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -255,8 +255,14 @@ class UnfoldPlotter:
 
             ax_.set_xlim(xmin, xmax)
             ax_.set_ylim(*ylim)
-            if title:
-                ax_.set_title(title)
+            spin_title = f'Spin {"Up" if ispin == 0 else "Down"}'
+            if title is None and nspin > 1:
+                plot_title = spin_title
+            elif nspin > 1:
+                plot_title = f'{title} ({spin_title})'
+            else:
+                plot_title = title
+            ax_.set_title(plot_title)
 
             # Label the kpoints
             self._add_kpoint_labels(ax_)
@@ -360,7 +366,14 @@ class UnfoldPlotter:
             ax_.imshow(sf[ispin], extent=extent, aspect='auto', origin='upper')
             ax_.set_ylim(ylim)
             ax_.set_xlim(0, sf.shape[2] - 1)
-            ax_.set_title(title)
+            spin_title = f'Spin {"Up" if ispin == 0 else "Down"}'
+            if title is None and nspin > 1:
+                plot_title = spin_title
+            elif nspin > 1:
+                plot_title = f'{title} ({spin_title})'
+            else:
+                plot_title = title
+            ax_.set_title(plot_title)
             self._add_kpoint_labels(ax_, x_is_kidx=True)
 
         axes[0].set_ylabel('Energy (eV)', labelpad=5)
@@ -539,8 +552,14 @@ class UnfoldPlotter:
             )
             ax_.set_xlim(0, kdist.max() - 1)
             ax_.set_ylim(ylim)
-            if title:
-                ax_.set_title(title)
+            spin_title = f'Spin {"Up" if ispin == 0 else "Down"}'
+            if title is None and nspin > 1:
+                plot_title = spin_title
+            elif nspin > 1:
+                plot_title = f'{title} ({spin_title})'
+            else:
+                plot_title = title
+            ax_.set_title(plot_title)
             self._add_kpoint_labels(ax_)
 
         axes[0].set_ylabel('Energy [eV]', labelpad=5)


### PR DESCRIPTION
This is a minor update to improve plotting aesthetics, including:
- Non-duplication of y-axis label for spin-polarised plotting
- Fixing a minor inaccuracy in the x-axis 
- Fixing the placement of the legend with spin-polarised plotting, with atoms/orbitals projections
- Adds titles for spin up/down so users know why two plots are shown

(Note that this does not solve @Iamkeli's issues in https://github.com/SMTG-Bham/easyunfold/issues/55 – can you please have a look at this when you get a chance @zhubonan)

e.g. spin titles:
![image](https://github.com/user-attachments/assets/2aa90818-5e0e-41a9-a230-0cb3a2aaba24)


e.g. x-axis fix:
![image](https://github.com/user-attachments/assets/d6e50999-2abe-4abc-9ed6-5682779ffc9a)
![image](https://github.com/user-attachments/assets/295b42d2-2abd-4cc7-b519-fdce6934be0d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Plot titles now consistently indicate spin channels when multiple spins are present.
  - Axis labeling is streamlined, reducing redundant y-axis labels in multi-spin plots.
  - X-axis limits are more accurately aligned with data indexing.
  - Legends in projected plots are better placed and only shown when appropriate.
  - Layout adjustments ensure legends and plots are displayed clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->