### PR TITLE
Fix bug caused by floating point 

### DIFF
--- a/easyunfold/unfold.py
+++ b/easyunfold/unfold.py
@@ -55,7 +55,8 @@ def find_K_from_k(k: np.ndarray, M: np.ndarray):
     M = np.array(M)
     Kc = np.dot(k, M.T)  # Primitive cell kpoint in supercell fractional coordinates
     KG = wrap_kpoints(Kc)  # Wrap to the 1st BZ
-    G = np.array(Kc - KG, dtype=int)  # Compute the G vector in supercell fractional coordinates
+    G = np.round(Kc - KG).astype(int)  # Compute the G vector in supercell fractional coordinates
+
     return KG, G
 
 

--- a/easyunfold/utils.py
+++ b/easyunfold/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 from castepinput import CellInput, Block
 
 RE_COMMENT = re.compile(r'[!#]')
-ATOL = 1e-9
+ATOL = 1e-8
 
 
 def write_kpoints(kpoints: Union[np.ndarray, list], outpath, *args, code='vasp', **kwargs):

--- a/easyunfold/utils.py
+++ b/easyunfold/utils.py
@@ -269,7 +269,7 @@ def reduce_kpoints(kpoints: Union[list, np.ndarray], time_reversal=True, roundin
     def equality_time_reversal(x, y):
         """Check if x == y or x == -y"""
         return np.allclose(x, y, atol=ATOL) | np.allclose(x, -y, atol=ATOL)
-        
+
     _, unique_id, inv_mapping = find_unique(kpoints_rounded, equality_time_reversal if time_reversal else equality_close)
     unique_k = kpoints[unique_id]
     return unique_k, unique_id, inv_mapping

--- a/easyunfold/utils.py
+++ b/easyunfold/utils.py
@@ -269,11 +269,8 @@ def reduce_kpoints(kpoints: Union[list, np.ndarray], time_reversal=True, roundin
     def equality_time_reversal(x, y):
         """Check if x == y or x == -y"""
         return np.allclose(x, y, atol=ATOL) | np.allclose(x, -y, atol=ATOL)
-
-    if time_reversal:
-        _, unique_id, inv_mapping = find_unique(kpoints_rounded, equality_time_reversal)
-    else:
-        _, unique_id, inv_mapping = find_unique(kpoints_rounded, equality_close)
+        
+    _, unique_id, inv_mapping = find_unique(kpoints_rounded, equality_time_reversal if time_reversal else equality_close)
     unique_k = kpoints[unique_id]
     return unique_k, unique_id, inv_mapping
 

--- a/tests/test_unfold.py
+++ b/tests/test_unfold.py
@@ -150,7 +150,13 @@ def test_unfold(si_project_dir, tag, nspin, ncl, nbands_expected, datapath):
     # shutil.copyfile(si_project_dir / 'KPOINTS_sc',
     #                 datapath('Si-project') / f'{folder_name}/KPOINTS_easyunfold')
     kpoints_sc_ref = read_kpoints(si_project_dir / f'{folder_name}/KPOINTS_easyunfold')[0]
-    np.testing.assert_allclose(kpoints_sc, kpoints_sc_ref)
+    for kpt in kpoints_sc_ref:
+        found = False
+        for ref in kpoints_sc:
+            if np.allclose(kpt, ref, atol=1e-9):
+                found = True
+                break
+        assert found, f'Kpoint {kpt} not found in the unfolded kpoints'
 
     # Test unfold
     sws = unfolder.get_spectral_weights(si_project_dir / f'{folder_name}/WAVECAR', ncl=ncl)
@@ -194,7 +200,15 @@ def test_unfold_castep(si_project_dir, tag, nspin, ncl, nbands_expected, datapat
     kpoints_sc_ref = read_kpoints(si_project_dir / f'{folder_name}/easyunfold_sc_kpoints.cell', code='castep')[0]
     # shutil.copyfile(si_project_dir / 'easyunfold_sc_kpoints.cell',  # to update
     #                 datapath('Si-project') / f'{folder_name}/easyunfold_sc_kpoints.cell')
-    np.testing.assert_allclose(kpoints_sc, kpoints_sc_ref)
+    for kpt in kpoints_sc_ref:
+        found = False
+        for ref in kpoints_sc:
+            ref = np.array(ref)
+            # Note - allow time reversal symmetry when checking the equivalence of kpoints
+            if np.allclose(kpt, ref, atol=1e-9) or np.allclose(kpt, -ref, atol=1e-9):
+                found = True
+                break
+        assert found, f'Kpoint {kpt} not found in the unfolded kpoints'
 
     # Test unfold
     sws = unfolder.get_spectral_weights(si_project_dir / f'{folder_name}/Si_211_unfold/easyunfold_sc_kpoints.orbitals', ncl=ncl)


### PR DESCRIPTION
This PR should fix #64 which was caused by incorrect G vector returned by the `find_K_from_k` function due to floating point rounding. 

Changes included in this PR:
* Use `np.allclose` for checking equality for floating point numbers. 
* Fix a bug where the G vector calculated can be wrong due to floating point rounding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical accuracy when deriving reciprocal-space integer vectors by rounding before integer conversion.
  * Standardized floating‑point comparisons with a small tolerance to make k‑point uniqueness and reduction more robust.

* **Tests**
  * Updated tests to verify k‑points using approximate per‑point membership checks, allowing for reordering and time‑reversal equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->