### PR TITLE
`numpy` `v2` compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
   - id: forbid-new-submodules
     exclude: (example)
 
-- repo: https://github.com/pre-commit/mirrors-yapf
-  rev: v0.30.0
+- repo: https://github.com/google/yapf
+  rev: v0.43.0
   hooks:
   - id: yapf
     name: yapf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
   rev: v0.43.0
   hooks:
   - id: yapf
+    language_version: python3.12
     name: yapf
     types: [python]
     args: ['-i']

--- a/easyunfold/__init__.py
+++ b/easyunfold/__init__.py
@@ -2,4 +2,4 @@
 Collection of code for band unfolding
 """
 
-__version__ = '0.3.10'
+__version__ = '0.4.0'

--- a/easyunfold/cli.py
+++ b/easyunfold/cli.py
@@ -528,7 +528,9 @@ def process_dos(dos, dos_elements, dos_orbitals, dos_atoms, gaussian, total_only
                     if orbital not in draft_dos_elements[atom] and orbital != 'all':
                         draft_dos_elements[atom] += (orbital,)
 
-            if orbitals and any(i in orbital for my_tuple in draft_dos_elements.values() for orbital in my_tuple
+            if orbitals and any(i in orbital
+                                for my_tuple in draft_dos_elements.values()
+                                for orbital in my_tuple
                                 for i in ['x', 'y', 'z']) and dos_orbitals is None:
                 dos_orbitals = {}
                 for atom, orbital_tuple in draft_dos_elements.items():

--- a/easyunfold/unfold.py
+++ b/easyunfold/unfold.py
@@ -855,7 +855,7 @@ class Unfold:
         gvecs = np.dot(Gvecs, np.linalg.inv(self.M).T)
         # Deviation from the perfect sites
         gd = gvecs - np.round(gvecs)
-        match = np.alltrue(np.abs(gd) < epsilon, axis=1)
+        match = np.all(np.abs(gd) < epsilon, axis=1)
 
         return Gvecs[match], Gvecs
 
@@ -866,10 +866,10 @@ class Unfold:
         kpts_wrapped = wrap_kpoints(self.wfc.kpoints)
         K0_wrapped = wrap_kpoints(K0)
         for ii in range(self.wfc.nkpts):
-            if np.alltrue(np.abs(kpts_wrapped[ii] - K0_wrapped) < 1E-5):
+            if np.all(np.abs(kpts_wrapped[ii] - K0_wrapped) < 1E-5):
                 return ii + 1, False
             # Check for kpoint related with time-reversal symmetry
-            if self.time_reversal and np.alltrue(np.abs(kpts_wrapped[ii] + K0_wrapped) < 1E-5):
+            if self.time_reversal and np.all(np.abs(kpts_wrapped[ii] + K0_wrapped) < 1E-5):
                 # This actually returns the index of -K0
                 return ii + 1, True
         raise ValueError('Cannot find the corresponding K-points in WAVECAR!')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "easyunfold"
-authors = [{name = "Bonan Zhu", email = "zhubonan@outlook.com"}, {name = "Seán Kavanagh", email = "skavanagh@seas.harvard.edu"}]
+authors = [{name = "Bonan Zhu", email = "zhubonan@outlook.com"}, {name = "Seán Kavanagh", email = "sk2045@cam.ac.uk"}]
 readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = [
@@ -14,8 +14,8 @@ classifiers = [
 dynamic = ["version", "description"]
 requires-python = ">=3.7"
 
-dependencies = ["scipy~=1.0", "numpy~=1.0", "matplotlib~=3.0", "ase~=3.14", "spglib~=2.0", "click",
-                "monty", "tqdm~=4.0", "tabulate~=0.8", "colormath~=3.0", "castepxbin~=0.3.0", "castepinput~=0.1"]
+dependencies = ["scipy>=1.0", "numpy>=1.0", "matplotlib>=3.0", "ase>=3.14", "spglib>=2.0", "click",
+                "monty", "tqdm>=4.0", "tabulate>=0.8", "colormath>=3.0", "castepxbin>=0.3.0", "castepinput>=0.1"]
 
 [project.urls]
 "Homepage" = "https://github.com/SMTG-Bham/easyunfold"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for the CLI system
 """
+import contextlib
 import os
 from pathlib import Path
 import pytest
@@ -453,11 +454,13 @@ def test_help(nabis2_project_dir):
 
 def _check_dos_atom_orbital_plots(output):
     print(output.stdout)
-    print(output.stderr)
+    with contextlib.suppress(Exception):
+        print(output.stderr)
     print(output)
     assert output.exit_code == 0
     assert Path('unfold.png').is_file()
     Path('unfold.png').unlink()
+
 
 def test_dos_atom_orbital_plots(nabis2_project_dir):
     """Test various dos/atom/orbital etc plot options with NaBiS2"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,6 +451,14 @@ def test_help(nabis2_project_dir):
     assert not Path('unfold.png').is_file()
 
 
+def _check_dos_atom_orbital_plots(output):
+    print(output.stdout)
+    print(output.stderr)
+    print(output)
+    assert output.exit_code == 0
+    assert Path('unfold.png').is_file()
+    Path('unfold.png').unlink()
+
 def test_dos_atom_orbital_plots(nabis2_project_dir):
     """Test various dos/atom/orbital etc plot options with NaBiS2"""
     os.chdir(nabis2_project_dir)
@@ -722,9 +730,3 @@ def test_dos_atom_orbital_plots(nabis2_project_dir):
         ],
     )
     _check_dos_atom_orbital_plots(output)
-
-
-def _check_dos_atom_orbital_plots(output):
-    assert output.exit_code == 0
-    assert Path('unfold.png').is_file()
-    Path('unfold.png').unlink()

--- a/tests/test_procar.py
+++ b/tests/test_procar.py
@@ -67,8 +67,7 @@ def test_procar():
     # atoms, happens for some bands (3 in this case) at high-symmetry kpoints due to orthogonal projections on
     # spherical harmonics)
     num_zero = np.sum([
-        1 for x in range(procar.proj_data.shape[0]) for y in range(procar.proj_data.shape[1])
-        for z in range(procar.proj_data.shape[2])
+        1 for x in range(procar.proj_data.shape[0]) for y in range(procar.proj_data.shape[1]) for z in range(procar.proj_data.shape[2])
         if np.isclose(procar.proj_data[x, y, z, :, :].sum(), 0)
     ])
     assert np.isclose(


### PR DESCRIPTION
This PR adds a small modification to `easyunfold` to be compatible with `numpy` >=2 (while still being compatible with v1).

Many mat sci packages are now supporting `numpy` v2 (e.g. `pymatgen`), but `easyunfold` currently sets a hard requirement for it to be v1 which is very restrictive for many people's environments. I have updated this and the other requirements here, as I think this is the better choice for avoiding issues as other packages are further developed. Of course open to dissenting arguments!

Closes https://github.com/SMTG-Bham/easyunfold/issues/67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust boolean matching in overlap and index calculations for improved correctness.

* **Chores**
  * Updated author contact information.
  * Relaxed dependency version constraints to broaden environment compatibility.
  * Bumped package version to 0.4.0.

* **Tests**
  * Reorganized a test helper for plot validation with no behavior change.

* **Style**
  * Upgraded code formatter configuration to a newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->